### PR TITLE
Added support for bootstrapping orgId registration by request.

### DIFF
--- a/src/main/java/no/fint/provider/events/admin/AdminController.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminController.java
@@ -22,6 +22,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.net.URI;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,7 +62,7 @@ public class AdminController {
     public List<Map> getOrganizations() {
         return adminService.getOrgIds().entrySet().stream().map(entry -> ImmutableMap.of(
                 "orgId", entry.getKey(),
-                "registered", entry.getValue()
+                "registered", new Date(entry.getValue())
         )).collect(Collectors.toList());
     }
 
@@ -70,7 +71,7 @@ public class AdminController {
         if (adminService.isRegistered(orgId)) {
             return ResponseEntity.ok(ImmutableMap.of(
                     "orgId", orgId,
-                    "registered", adminService.getTimestamp(orgId)
+                    "registered", new Date(adminService.getTimestamp(orgId))
             ));
         } else {
             return ResponseEntity.notFound().build();

--- a/src/main/java/no/fint/provider/events/admin/AdminDownstreamSubscriber.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminDownstreamSubscriber.java
@@ -32,16 +32,12 @@ public class AdminDownstreamSubscriber implements FintEventListener {
         if (event.isRegisterOrgId()) {
             if (StringUtils.isEmpty(event.getOrgId())) {
                 log.info("Bootstrapping consumer with registered organizations: {}", adminService.getOrgIds().keySet());
-                Boolean result = adminService
+                adminService
                         .getOrgIds()
                         .keySet()
                         .stream()
                         .map(orgId -> new Event(orgId, Constants.COMPONENT, DefaultActions.REGISTER_ORG_ID, Constants.COMPONENT))
-                        .map(fintEvents::sendUpstream)
-                        .reduce(Boolean.TRUE, Boolean::logicalAnd);
-                if (!result) {
-                    log.warn("Unable to send some of the events!");
-                }
+                        .forEach(fintEvents::sendUpstream);
             } else {
                 adminService.register(event.getOrgId(), event.getClient());
             }

--- a/src/main/java/no/fint/provider/events/admin/AdminDownstreamSubscriber.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminDownstreamSubscriber.java
@@ -1,9 +1,12 @@
 package no.fint.provider.events.admin;
 
 import lombok.extern.slf4j.Slf4j;
+import no.fint.event.model.DefaultActions;
 import no.fint.event.model.Event;
 import no.fint.events.FintEventListener;
 import no.fint.events.FintEvents;
+import no.fint.provider.events.Constants;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -27,7 +30,21 @@ public class AdminDownstreamSubscriber implements FintEventListener {
     @Override
     public void accept(Event event) {
         if (event.isRegisterOrgId()) {
-            adminService.register(event.getOrgId(), event.getClient());
+            if (StringUtils.isEmpty(event.getOrgId())) {
+                log.info("Bootstrapping consumer with registered organizations: {}", adminService.getOrgIds().keySet());
+                Boolean result = adminService
+                        .getOrgIds()
+                        .keySet()
+                        .stream()
+                        .map(orgId -> new Event(orgId, Constants.COMPONENT, DefaultActions.REGISTER_ORG_ID, Constants.COMPONENT))
+                        .map(fintEvents::sendUpstream)
+                        .reduce(Boolean.TRUE, Boolean::logicalAnd);
+                if (!result) {
+                    log.warn("Unable to send some of the events!");
+                }
+            } else {
+                adminService.register(event.getOrgId(), event.getClient());
+            }
         } else {
             log.error("Cannot process system event {}", event.getAction());
         }

--- a/src/main/java/no/fint/provider/events/testmode/consumer/TestModeController.java
+++ b/src/main/java/no/fint/provider/events/testmode/consumer/TestModeController.java
@@ -3,6 +3,7 @@ package no.fint.provider.events.testmode.consumer;
 
 import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
+import no.fint.event.model.DefaultActions;
 import no.fint.event.model.Event;
 import no.fint.events.FintEventListener;
 import no.fint.events.FintEvents;
@@ -40,6 +41,7 @@ public class TestModeController implements FintEventListener {
                 fintEvents.registerUpstreamListener(event.getOrgId(), this);
             }
         }));
+        fintEvents.sendDownstream(new Event("", TestModeConstants.SOURCE, DefaultActions.REGISTER_ORG_ID, TestModeConstants.CLIENT));
     }
 
     @PostMapping


### PR DESCRIPTION
When provider receives `REGISTER_ORG_ID` with an empty orgId, it will respond with `REGISTER_ORG_ID` events for all active organizations.

This ensure that a freshly started consumer is bootstrapped with all the active orgIds.