### PR TITLE
Respond to invalid orgIDs with a dummy emitter.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-web')
     runtime('org.springframework.boot:spring-boot-starter-actuator')
 
-    testCompile('no.fint:fint-test-utils:0.0.4')
+    testCompile('no.fint:fint-test-utils:0.0.5-rc-1')
     testCompile("cglib:cglib-nodep:${cglibVersion}")
     testCompile("org.spockframework:spock-spring:${spockSpringVersion}")
     testCompile("org.spockframework:spock-core:${spockSpringVersion}")

--- a/src/test/groovy/no/fint/provider/events/sse/SseControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/sse/SseControllerSpec.groovy
@@ -5,6 +5,7 @@ import no.fint.events.FintEvents
 import no.fint.provider.events.admin.AdminService
 import no.fint.provider.events.subscriber.DownstreamSubscriber
 import no.fint.test.utils.MockMvcSpecification
+import org.hamcrest.CoreMatchers
 import org.springframework.test.web.servlet.MockMvc
 
 class SseControllerSpec extends MockMvcSpecification {
@@ -47,7 +48,7 @@ class SseControllerSpec extends MockMvcSpecification {
         1 * adminService.register('rogfk.no', 'client') >> false
         0 * sseService.subscribe('123', 'rogfk.no', 'client')
         0 * fintEvents.registerDownstreamListener('rogfk.no', downstreamSubscriber)
-        response.andExpect(status().is4xxClientError())
+        response.andExpect(header().string('x-Error', CoreMatchers.startsWith('Invalid orgID')))
 
     }
 


### PR DESCRIPTION
This stalls adapters not enabled so they won't reconnect all the time.