### PR TITLE
Sse context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:4.10.2-jdk8-alpine as builder
+FROM gradle:4.10.3-jdk8-alpine as builder
 USER root
 COPY . .
 RUN gradle --no-daemon build

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.3.6
+version=2.1.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/no/fint/provider/events/ProviderProps.java
+++ b/src/main/java/no/fint/provider/events/ProviderProps.java
@@ -32,4 +32,7 @@ public class ProviderProps {
     @Value("${fint.provider.assets.endpoint:}")
     private String assetsEndpoint;
 
+    @Value("${server.context-path:/}")
+    private String contextPath;
+
 }

--- a/src/main/java/no/fint/provider/events/sse/SseController.java
+++ b/src/main/java/no/fint/provider/events/sse/SseController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.fint.event.model.HeaderConstants;
 import no.fint.events.FintEvents;
 import no.fint.provider.events.Constants;
+import no.fint.provider.events.ProviderProps;
 import no.fint.provider.events.admin.AdminService;
 import no.fint.provider.events.subscriber.DownstreamSubscriber;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,9 @@ public class SseController {
     @Autowired
     private DownstreamSubscriber downstreamSubscriber;
 
+    @Autowired
+    private ProviderProps props;
+
     @ApiOperation(value = "Connect SSE client", notes = "Endpoint to register SSE client.")
     @GetMapping("/{id}")
     public ResponseEntity<SseEmitter> subscribe(
@@ -61,7 +65,7 @@ public class SseController {
             List<SseClient> sseClients = new ArrayList<>();
             value.forEach(emitter -> sseClients.add(new SseClient(emitter.getRegistered(), emitter.getId(), emitter.getClient(), emitter.getEventCounter().get())));
 
-            orgs.add(new SseOrg(key, sseClients));
+            orgs.add(new SseOrg(props.getContextPath(), key, sseClients));
         });
         return orgs;
     }

--- a/src/main/java/no/fint/provider/events/sse/SseOrg.java
+++ b/src/main/java/no/fint/provider/events/sse/SseOrg.java
@@ -8,6 +8,7 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 public class SseOrg {
+    private String path;
     private String orgId;
     private List<SseClient> clients;
 }

--- a/src/test/groovy/no/fint/provider/events/sse/SseControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/sse/SseControllerSpec.groovy
@@ -2,6 +2,7 @@ package no.fint.provider.events.sse
 
 import no.fint.event.model.HeaderConstants
 import no.fint.events.FintEvents
+import no.fint.provider.events.ProviderProps
 import no.fint.provider.events.admin.AdminService
 import no.fint.provider.events.subscriber.DownstreamSubscriber
 import no.fint.test.utils.MockMvcSpecification
@@ -14,13 +15,15 @@ class SseControllerSpec extends MockMvcSpecification {
     private FintEvents fintEvents
     private MockMvc mockMvc
     private AdminService adminService
+    private ProviderProps props
 
     void setup() {
         sseService = Mock()
         fintEvents = Mock()
         adminService = Mock()
+        props = Mock()
         downstreamSubscriber = Mock(DownstreamSubscriber)
-        controller = new SseController(sseService: sseService, fintEvents: fintEvents, downstreamSubscriber: downstreamSubscriber, adminService: adminService)
+        controller = new SseController(sseService: sseService, fintEvents: fintEvents, downstreamSubscriber: downstreamSubscriber, adminService: adminService, props: props)
         mockMvc = standaloneSetup(controller)
     }
 


### PR DESCRIPTION
This PR adds the servlet context path to the `/sse/clients` endpoint, to make reporting easier if querying several providers for SSE connections simultaneously.

I regularly use the following query to check adapter connectivity, and the output could benefit from having the context path available.

```
./fint-curl-v2.sh -fs https://beta.felleskomponent.no/administrasjon/{personal,organisasjon,kodeverk,fullmakt}/provider/sse/clients |\
jq '.[] | select(.orgId == "viken.no") | .orgId, "  " + .clients[].registered' -r
```