### PR TITLE
SSE with actions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ classes/
 out
 .DS_Store
 *.iml
+/.classpath
+/.project
+/.settings/
+/.vscode/
+/bin/

--- a/src/main/java/no/fint/provider/events/sse/FintSseEmitter.java
+++ b/src/main/java/no/fint/provider/events/sse/FintSseEmitter.java
@@ -7,7 +7,10 @@ import org.apache.commons.lang3.time.FastDateFormat;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Getter
@@ -16,6 +19,7 @@ public class FintSseEmitter extends SseEmitter {
     private String id;
     private String client;
     private String registered;
+    private Set<String> actions = new HashSet<>();
     private final AtomicInteger eventCounter = new AtomicInteger();
     private static final DatePrinter DATE_PRINTER = FastDateFormat.getInstance("HH:mm:ss dd/MM/yyyy");
 

--- a/src/main/java/no/fint/provider/events/sse/FintSseEmitter.java
+++ b/src/main/java/no/fint/provider/events/sse/FintSseEmitter.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang3.time.FastDateFormat;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -38,11 +37,11 @@ public class FintSseEmitter extends SseEmitter {
         registered = DATE_PRINTER.format(new Date());
     }
 
-	@Override
-	public void send(SseEventBuilder builder) throws IOException {
-		eventCounter.incrementAndGet();
-		super.send(builder);
-	}
-    
-    
+    @Override
+    public void send(SseEventBuilder builder) throws IOException {
+        eventCounter.incrementAndGet();
+        super.send(builder);
+    }
+
+
 }

--- a/src/main/java/no/fint/provider/events/sse/FintSseEmitters.java
+++ b/src/main/java/no/fint/provider/events/sse/FintSseEmitters.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 public class FintSseEmitters implements Iterable<FintSseEmitter> {
     private final int maxSize;
@@ -40,6 +41,10 @@ public class FintSseEmitters implements Iterable<FintSseEmitter> {
 
     public int size() {
         return emitters.size();
+    }
+
+    public Stream<FintSseEmitter> stream() {
+        return emitters.stream();
     }
 
     @Override

--- a/src/main/java/no/fint/provider/events/sse/FintSseEmitters.java
+++ b/src/main/java/no/fint/provider/events/sse/FintSseEmitters.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -11,6 +12,7 @@ public class FintSseEmitters implements Iterable<FintSseEmitter> {
     private final int maxSize;
     private final ConcurrentLinkedDeque<FintSseEmitter> emitters;
     private final Consumer<FintSseEmitter> removeCallback;
+    private final ConcurrentSkipListSet<String> actions;
 
     public FintSseEmitters(int maxSize, Consumer<FintSseEmitter> removeCallback) {
         this.maxSize = maxSize;
@@ -20,6 +22,7 @@ public class FintSseEmitters implements Iterable<FintSseEmitter> {
         } else {
             this.removeCallback = removeCallback;
         }
+        actions = new ConcurrentSkipListSet<>();
     }
 
     public void add(FintSseEmitter emitter) {
@@ -29,6 +32,7 @@ public class FintSseEmitters implements Iterable<FintSseEmitter> {
         }
 
         emitters.addFirst(emitter);
+        actions.addAll(emitter.getActions());
     }
 
     public void remove(FintSseEmitter emitter) {
@@ -37,6 +41,10 @@ public class FintSseEmitters implements Iterable<FintSseEmitter> {
 
     public Optional<FintSseEmitter> get(String id) {
         return emitters.stream().filter(registered -> registered.getId().equals(id)).findFirst();
+    }
+
+    public boolean supportsAction(String action) {
+        return actions.contains(action);
     }
 
     public int size() {

--- a/src/main/java/no/fint/provider/events/sse/SseClient.java
+++ b/src/main/java/no/fint/provider/events/sse/SseClient.java
@@ -3,6 +3,9 @@ package no.fint.provider.events.sse;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.Collections;
+import java.util.Set;
+
 @Data
 @AllArgsConstructor
 public class SseClient {
@@ -10,4 +13,5 @@ public class SseClient {
     private String id;
     private String client;
     private int events;
+    private Set<String> actions;
 }

--- a/src/main/java/no/fint/provider/events/sse/SseController.java
+++ b/src/main/java/no/fint/provider/events/sse/SseController.java
@@ -10,12 +10,14 @@ import no.fint.provider.events.Constants;
 import no.fint.provider.events.ProviderProps;
 import no.fint.provider.events.admin.AdminService;
 import no.fint.provider.events.subscriber.DownstreamSubscriber;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -45,10 +47,14 @@ public class SseController {
     public ResponseEntity<SseEmitter> subscribe(
             @ApiParam(Constants.SWAGGER_X_ORG_ID) @RequestHeader(HeaderConstants.ORG_ID) String orgId,
             @ApiParam("ID of client.") @RequestHeader(HeaderConstants.CLIENT) String client,
+            @RequestHeader(value = "x-fint-actions", required = false, defaultValue = "") String actions,
             @ApiParam("Global unique id for the client. Typically a UUID.") @PathVariable String id) {
         log.info("{}: Client {}, ID {}", orgId, client, id);
         if (adminService.register(orgId, client)) {
-            SseEmitter emitter = sseService.subscribe(id, orgId, client);
+            FintSseEmitter emitter = sseService.subscribe(id, orgId, client);
+            if (StringUtils.isNotBlank(actions)) {
+                emitter.getActions().addAll(Arrays.asList(StringUtils.split(actions, ",;:")));
+            }
             fintEvents.registerDownstreamListener(orgId, downstreamSubscriber);
             return ResponseEntity.ok(emitter);
         } else {
@@ -63,7 +69,7 @@ public class SseController {
         List<SseOrg> orgs = new ArrayList<>();
         clients.forEach((key, value) -> {
             List<SseClient> sseClients = new ArrayList<>();
-            value.forEach(emitter -> sseClients.add(new SseClient(emitter.getRegistered(), emitter.getId(), emitter.getClient(), emitter.getEventCounter().get())));
+            value.forEach(emitter -> sseClients.add(new SseClient(emitter.getRegistered(), emitter.getId(), emitter.getClient(), emitter.getEventCounter().get(), emitter.getActions())));
 
             orgs.add(new SseOrg(props.getContextPath(), key, sseClients));
         });

--- a/src/main/java/no/fint/provider/events/sse/SseController.java
+++ b/src/main/java/no/fint/provider/events/sse/SseController.java
@@ -49,7 +49,7 @@ public class SseController {
             @ApiParam("ID of client.") @RequestHeader(HeaderConstants.CLIENT) String client,
             @RequestHeader(value = "x-fint-actions", required = false, defaultValue = "") String actions,
             @ApiParam("Global unique id for the client. Typically a UUID.") @PathVariable String id) {
-        log.info("{}: Client {}, ID {}", orgId, client, id);
+        log.info("{}: Client {}, ID {}, actions {}", orgId, client, id, actions);
         if (adminService.register(orgId, client)) {
             FintSseEmitter emitter = sseService.subscribe(id, orgId, client);
             if (StringUtils.isNotBlank(actions)) {

--- a/src/main/java/no/fint/provider/events/sse/SseController.java
+++ b/src/main/java/no/fint/provider/events/sse/SseController.java
@@ -54,7 +54,7 @@ public class SseController {
         if (adminService.register(orgId, client)) {
             FintSseEmitter emitter = sseService.subscribe(id, orgId, client);
             if (StringUtils.isNotBlank(actions)) {
-                emitter.getActions().addAll(Arrays.asList(StringUtils.split(actions, ",;:")));
+                emitter.getActions().addAll(Arrays.asList(StringUtils.split(actions, ",;: ")));
             }
             fintEvents.registerDownstreamListener(orgId, downstreamSubscriber);
             return ResponseEntity.ok(emitter);

--- a/src/main/java/no/fint/provider/events/sse/SseService.java
+++ b/src/main/java/no/fint/provider/events/sse/SseService.java
@@ -65,17 +65,15 @@ public class SseService {
     }
 
     private Consumer<FintSseEmitter> consumeEvent(Event event) {
-        return (fintSseEmitter -> sendEvent(event, fintSseEmitter));
-    }
-
-    private void sendEvent(Event event, FintSseEmitter emitter) {
-        try {
-            SseEmitter.SseEventBuilder builder = SseEmitter.event().id(event.getCorrId()).name(event.getAction()).data(event).reconnectTime(5000L);
-            emitter.send(builder);
-        } catch (IOException e) {
-            log.info("Error sending message to SseEmitter {} {}: {}", emitter.getClient(), emitter.getId(), e.getMessage());
-            log.debug("Details: {}", event, e);
-        }
+        return (fintSseEmitter -> {
+            try {
+                SseEmitter.SseEventBuilder builder = SseEmitter.event().id(event.getCorrId()).name(event.getAction()).data(event).reconnectTime(5000L);
+                fintSseEmitter.send(builder);
+            } catch (IOException e) {
+                log.info("Error sending message to SseEmitter {} {}: {}", fintSseEmitter.getClient(), fintSseEmitter.getId(), e.getMessage());
+                log.debug("Details: {}", event, e);
+            }
+        });
     }
 
     public void sendHeartbeat() {

--- a/src/test/groovy/no/fint/provider/events/admin/AdminDownstreamSubscriberSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminDownstreamSubscriberSpec.groovy
@@ -38,4 +38,16 @@ class AdminDownstreamSubscriberSpec extends Specification {
         then:
         0 * adminService.register('rogfk.no', 'test')
     }
+
+    def 'Boostrap orgid registration'() {
+        given:
+        def event = new Event('', '', DefaultActions.REGISTER_ORG_ID.name(), '')
+
+        when:
+        subscriber.accept(event)
+
+        then:
+        2 * adminService.getOrgIds() >> ['jalla.org' : 12, 'balla.com': 14]
+        2 * fintEvents.sendUpstream(_ as Event)
+    }
 }

--- a/src/test/groovy/no/fint/provider/events/sse/SseServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/sse/SseServiceSpec.groovy
@@ -62,14 +62,16 @@ class SseServiceSpec extends Specification {
 
     def "Handle exception when trying to send message"() {
         given:
-        def emitter = Mock(FintSseEmitter)
+        def emitter = Mock(FintSseEmitter) {
+            _ * getActions() >> Collections.singleton('GET_MONKEY')
+        }
         def emitters = FintSseEmitters.with(5)
         emitters.add(emitter)
         def clients = ['hfk.no': emitters] as ConcurrentHashMap
         sseService = new SseService(providerProps: props, clients: clients)
 
         when:
-        sseService.send(new Event(orgId: 'hfk.no'))
+        sseService.send(new Event(orgId: 'hfk.no', action: 'GET_MONKEY'))
 
         then:
         1 * emitter.send(_ as SseEmitter.SseEventBuilder) >> { throw new IOException('Test exception') }

--- a/src/test/groovy/no/fint/provider/events/sse/SseServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/sse/SseServiceSpec.groovy
@@ -92,7 +92,9 @@ class SseServiceSpec extends Specification {
 
     def "Run complete method for all registered emitters when shutting down"() {
         given:
-        def emitter = Mock(FintSseEmitter)
+        def emitter = Mock(FintSseEmitter) {
+            getActions() >> []
+        }
         def emitters = FintSseEmitters.with(5)
         emitters.add(emitter)
         def clients = ['hfk.no': emitters] as ConcurrentHashMap
@@ -109,6 +111,7 @@ class SseServiceSpec extends Specification {
         given:
         def emitter = Mock(FintSseEmitter) {
             getId() >> 'fake'
+            getActions() >> []
         }
         def emitters = FintSseEmitters.with(5)
         emitters.add(emitter)


### PR DESCRIPTION
Extend SSE controller with support for clients registering which actions they support.

The SSE controller endpoint looks for a new header, `x-fint-actions`, which contains a comma separated list of the actions a given adapter supports.

Then, when dispatching events, the provider checks whether any of the SSE connections for the orgId has supported actions registered.  In this case the event is distributed to the connections supporting the action.

If however none of the SSE connections have registered with `x-fint-actions`, all connections receive the event.