### PR TITLE
Enable Azure Eventhub audit plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ classes/
 out
 .DS_Store
 *.iml
+/.classpath
+/.project
+/.settings/
+/.vscode/
+/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:4.10.3-jdk8-alpine as builder
 USER root
 COPY . .
-RUN gradle --no-daemon build
+RUN gradle --no-daemon -Peventhub build
 
 FROM gcr.io/distroless/java
 ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM gradle:4.10.3-jdk8-alpine as builder
 USER root
 COPY . .
-RUN gradle --no-daemon -Peventhub build
+ARG buildFlags=""
+RUN gradle --no-daemon ${buildFlags} build
 
-FROM gcr.io/distroless/java
+FROM gcr.io/distroless/java:8
 ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError
 COPY --from=builder /home/gradle/build/deps/external/*.jar /data/
 COPY --from=builder /home/gradle/build/deps/fint/*.jar /data/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
 pipeline {
+    parameters {
+        string(name: 'BUILD_FLAGS', defaultValue: '', description: 'Gradle build flags')
+    }
     agent { label 'docker' }
     stages {
         stage('Build') {
             steps {
                 sh 'git clean -fdx'
-                sh "docker build -t ${GIT_COMMIT} ."
+                sh "docker build --tag ${GIT_COMMIT} --build-arg buildFlags=${params.BUILD_FLAGS} ."
             }
         }
         stage('Publish Latest') {

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile('org.glassfish.jersey.core:jersey-common:2.29.1')
     
     if (project.hasProperty("eventhub")) {
-        compile('no.fint:fint-audit-azure-eventhub-plugin:0.2.0')
+        compile('no.fint:fint-audit-azure-eventhub-plugin:0.3.0')
         compile('io.projectreactor:reactor-core:3.3.2.RELEASE')
     } else {
         compile('no.fint:fint-audit-mongo-plugin:1.7.0-rc-2')

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     
     if (project.hasProperty("eventhub")) {
         compile('no.fint:fint-audit-azure-eventhub-plugin:0.2.0')
+        compile('io.projectreactor:reactor-core:3.3.2.RELEASE')
     } else {
         compile('no.fint:fint-audit-mongo-plugin:1.7.0-rc-2')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile('org.glassfish.jersey.core:jersey-common:2.29.1')
     
     if (project.hasProperty("eventhub")) {
-        compile('no.fint:fint-audit-azure-eventhub-plugin:0.1.0')
+        compile('no.fint:fint-audit-azure-eventhub-plugin:0.2.0')
     } else {
         compile('no.fint:fint-audit-mongo-plugin:1.7.0-rc-2')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,12 @@ dependencies {
     compile('org.glassfish.jersey.core:jersey-client:2.29.1')
     compile('org.glassfish.jersey.core:jersey-common:2.29.1')
     
-    compile('no.fint:fint-audit-mongo-plugin:1.7.0-rc-2')
+    if (project.hasProperty("eventhub")) {
+        compile('no.fint:fint-audit-azure-eventhub-plugin:0.1.0')
+    } else {
+        compile('no.fint:fint-audit-mongo-plugin:1.7.0-rc-2')
+    }
+    
     compile('no.fint:fint-events:2.2.0')
     compile('no.fint:fint-event-model:3.0.0')
     compile('no.fint:fint-springfox-extension:0.0.1')

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     compile('org.jooq:jool-java-8:0.9.14')
 
     compile('org.springframework.boot:spring-boot-starter-web')
+    compile('org.apache.tomcat.embed:tomcat-embed-core:8.5.45')
     runtime('org.springframework.boot:spring-boot-starter-actuator')
 
     testCompile('no.fint:fint-test-utils:0.0.4')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=2.1.0
+tomcat.version=8.5.45

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-echo "=> Building the binary"
-
-docker run --rm -v "$PWD":/project -w /project openjdk:alpine ./gradlew build

--- a/src/main/java/no/fint/provider/events/admin/AdminController.java
+++ b/src/main/java/no/fint/provider/events/admin/AdminController.java
@@ -4,15 +4,11 @@ import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
-import no.fint.audit.plugin.mongo.MongoAuditEvent;
 import no.fint.event.model.HeaderConstants;
 import no.fint.events.FintEvents;
 import no.fint.provider.events.Constants;
 import no.fint.provider.events.subscriber.DownstreamSubscriber;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.core.MongoOperations;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -20,8 +16,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
-import java.time.Duration;
-import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -40,23 +34,7 @@ public class AdminController {
     private AdminService adminService;
 
     @Autowired
-    private MongoOperations mongo;
-
-    @Autowired
     private DownstreamSubscriber downstreamSubscriber;
-
-    @GetMapping("/audit/events")
-    public List<MongoAuditEvent> getAllEvents() {
-        return mongo.findAll(MongoAuditEvent.class);
-    }
-
-    @GetMapping("/audit/events/since/{when}")
-    public List<MongoAuditEvent> queryEventsSince(@PathVariable String when) {
-        Duration duration = Duration.parse(when);
-        Criteria c = Criteria.where("timestamp").gt(ZonedDateTime.now().minus(duration).toInstant().toEpochMilli());
-        Query q = new Query(c);
-        return mongo.find(q, MongoAuditEvent.class);
-    }
 
     @GetMapping("/orgIds")
     public List<Map> getOrganizations() {

--- a/src/main/java/no/fint/provider/events/sse/SseController.java
+++ b/src/main/java/no/fint/provider/events/sse/SseController.java
@@ -42,7 +42,7 @@ public class SseController {
     private ProviderProps props;
 
     @ApiOperation(value = "Connect SSE client", notes = "Endpoint to register SSE client.")
-    @GetMapping("/{id}")
+    @GetMapping(value = "/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> subscribe(
             @ApiParam(Constants.SWAGGER_X_ORG_ID) @RequestHeader(HeaderConstants.ORG_ID) String orgId,
             @ApiParam("ID of client.") @RequestHeader(HeaderConstants.CLIENT) String client,

--- a/src/main/java/no/fint/provider/events/sse/SseController.java
+++ b/src/main/java/no/fint/provider/events/sse/SseController.java
@@ -11,6 +11,7 @@ import no.fint.provider.events.ProviderProps;
 import no.fint.provider.events.admin.AdminService;
 import no.fint.provider.events.subscriber.DownstreamSubscriber;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -21,7 +22,7 @@ import java.util.Map;
 
 @Slf4j
 @Api(tags = {"sse"}, description = "These endpoint is for handling SSE clients.")
-@RequestMapping(value = "/sse")
+@RequestMapping(value = "/sse", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
 @RestController
 public class SseController {
 

--- a/src/main/java/no/fint/provider/events/testmode/adapter/TestModeAdapter.java
+++ b/src/main/java/no/fint/provider/events/testmode/adapter/TestModeAdapter.java
@@ -1,7 +1,6 @@
 package no.fint.provider.events.testmode.adapter;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 import no.fint.event.model.Event;
 import no.fint.event.model.HeaderConstants;

--- a/src/test/groovy/no/fint/provider/events/admin/AdminControllerSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/admin/AdminControllerSpec.groovy
@@ -1,13 +1,10 @@
 package no.fint.provider.events.admin
 
-import no.fint.audit.plugin.mongo.MongoAuditEvent
-import no.fint.event.model.Event
+
 import no.fint.event.model.HeaderConstants
 import no.fint.events.FintEvents
 import no.fint.provider.events.subscriber.DownstreamSubscriber
 import no.fint.test.utils.MockMvcSpecification
-import org.springframework.data.mongodb.core.MongoOperations
-import org.springframework.data.mongodb.core.query.Query
 import org.springframework.http.HttpHeaders
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -15,7 +12,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 class AdminControllerSpec extends MockMvcSpecification {
     private DownstreamSubscriber downstreamSubscriber
     private AdminController controller
-    private MongoOperations mongoOperations
     private FintEvents fintEvents
     private AdminService adminService
     private MockMvc mockMvc
@@ -23,30 +19,9 @@ class AdminControllerSpec extends MockMvcSpecification {
     void setup() {
         downstreamSubscriber = Mock(DownstreamSubscriber)
         adminService = Mock(AdminService)
-        mongoOperations = Mock(MongoOperations)
         fintEvents = Mock(FintEvents)
-        controller = new AdminController(mongo: mongoOperations, fintEvents: fintEvents, adminService: adminService, downstreamSubscriber: downstreamSubscriber)
+        controller = new AdminController(fintEvents: fintEvents, adminService: adminService, downstreamSubscriber: downstreamSubscriber)
         mockMvc = standaloneSetup(controller)
-    }
-
-    def "GET all audit events"() {
-        when:
-        def response = mockMvc.perform(get('/admin/audit/events'))
-
-        then:
-        1 * mongoOperations.findAll(MongoAuditEvent) >> [new MongoAuditEvent(new Event(orgId: 'rogfk.no'), true)]
-        response.andExpect(status().isOk())
-                .andExpect(jsonPath('$[0].orgId').value(equalTo('rogfk.no')))
-    }
-
-    def "GET audit events since some timestamp"() {
-        when:
-        def response = mockMvc.perform(get('/admin/audit/events/since/PT1H'))
-
-        then:
-        1 * mongoOperations.find(_ as Query, MongoAuditEvent) >> [new MongoAuditEvent(new Event(orgId: 'rogfk.no'), true)]
-        response.andExpect(status().isOk())
-                .andExpect(jsonPath('$[0].orgId').value(equalTo('rogfk.no')))
     }
 
     def "POST new orgId"() {

--- a/src/test/groovy/no/fint/provider/events/eventstate/EventStateServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provider/events/eventstate/EventStateServiceSpec.groovy
@@ -1,7 +1,6 @@
 package no.fint.provider.events.eventstate
 
 import com.hazelcast.core.HazelcastInstance
-import com.hazelcast.core.IMap
 import no.fint.event.model.Event
 import no.fint.provider.events.ProviderProps
 import spock.lang.Specification


### PR DESCRIPTION
This PR enables Azure Eventhub audit.  Since the audit events no longer are available in Mongo, the admin controller for retrieving events had to be removed. 

The PR also includes workarounds for some errors that have surfaced in the provider recently:
- `java.lang.IllegalStateException: Calling [asyncError()] is not valid for a request with Async state [MUST_DISPATCH]`: Fixed by upgrading Tomcat to 8.5.45
- REST responses suddenly switching to XML: Fixed by adding `produces` attributes to the SseController endpoints.